### PR TITLE
fix: annoying mac 'unhandled key' sound

### DIFF
--- a/lib/features/machine/machine.dart
+++ b/lib/features/machine/machine.dart
@@ -41,8 +41,8 @@ class _MachineWidgetState extends State<MachineWidget> {
     LogicalKeySet(LogicalKeyboardKey.keyM): _onMutePressed,
     LogicalKeySet(LogicalKeyboardKey.keyP): _onPausePressed,
     for (int i = 0; i < 8; i++)
-      LogicalKeySet(LogicalKeyboardKey(LogicalKeyboardKey.digit1.keyId + i)): () =>
-          _onPartPressed(i),
+      LogicalKeySet(LogicalKeyboardKey(LogicalKeyboardKey.digit1.keyId + i)):
+          () => _onPartPressed(i),
   };
 
   @override
@@ -97,14 +97,17 @@ class _MachineWidgetState extends State<MachineWidget> {
       autofocus: true,
       descendantsAreFocusable: false,
       onKey: (FocusNode node, RawKeyEvent event) {
-        var result = KeyEventResult.ignored;
+        var handled = false;
         for (final activator in _shortcuts.keys) {
           if (activator.accepts(event, RawKeyboard.instance)) {
             _shortcuts[activator]!.call();
-            result = KeyEventResult.handled;
+            handled = true;
           }
         }
-        return result;
+
+        handled = _machine.input.onKey(event) || handled;
+
+        return handled ? KeyEventResult.handled : KeyEventResult.ignored;
       },
       child: FontLoader(
         builder: (BuildContext context, ui.Image font) {
@@ -132,7 +135,8 @@ class _MachineWidgetState extends State<MachineWidget> {
                             children: [
                               for (int i = 0; i < 7; i++) //
                                 Padding(
-                                  padding: const EdgeInsets.symmetric(horizontal: 3.0),
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 3.0),
                                   child: OutlinedButton(
                                     onPressed: () => _onPartPressed(i),
                                     child: Text(_partNames[i]),
@@ -160,7 +164,9 @@ class _MachineWidgetState extends State<MachineWidget> {
                       DebugOptionButton(
                         onPressed: _onMutePressed,
                         selected: _machine.sound.muted,
-                        icon: _machine.sound.muted ? Icons.volume_off : Icons.volume_up,
+                        icon: _machine.sound.muted
+                            ? Icons.volume_off
+                            : Icons.volume_up,
                       ),
                       DebugOptionButton(
                         onPressed: _onPausePressed,
@@ -241,7 +247,8 @@ class DebugOptionButton extends StatelessWidget {
     final theme = Theme.of(context);
     return IconButton(
       onPressed: onPressed,
-      icon: Icon(icon, color: selected ? theme.colorScheme.surfaceTint : Colors.white60),
+      icon: Icon(icon,
+          color: selected ? theme.colorScheme.surfaceTint : Colors.white60),
     );
   }
 }

--- a/lib/features/managers/input_manager.dart
+++ b/lib/features/managers/input_manager.dart
@@ -1,6 +1,12 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/services.dart'
-    show LogicalKeyboardKey, RawKeyDownEvent, RawKeyEvent, RawKeyUpEvent, RawKeyboard;
+    show
+        LogicalKeyboardKey,
+        RawKeyDownEvent,
+        RawKeyEvent,
+        RawKeyUpEvent,
+        RawKeyboard;
+import 'package:flutter/widgets.dart';
 
 enum InputKey {
   up(LogicalKeyboardKey.arrowUp),
@@ -21,28 +27,27 @@ class InputManager {
 
   bool isKeyPressed(InputKey key) => _keyboard[key] ?? false;
 
-  void start() {
-    RawKeyboard.instance.addListener(_onKey);
-  }
-
-  void _onKey(RawKeyEvent value) {
-    if (value is RawKeyDownEvent) {
-      // print('onKeyDn: ${value.logicalKey}');
-      _setKeyState(value.logicalKey, true);
-    } else if (value is RawKeyUpEvent) {
-      // print('onKeyUp: ${value.logicalKey}');
-      _setKeyState(value.logicalKey, false);
+  bool onKey(RawKeyEvent event) {
+    if (event is RawKeyDownEvent) {
+      // print('onKeyDn: ${event.logicalKey}');
+      return _setKeyState(event.logicalKey, true);
     }
+
+    if (event is RawKeyUpEvent) {
+      // print('onKeyUp: ${event.logicalKey}');
+      return _setKeyState(event.logicalKey, false);
+    }
+
+    return false;
   }
 
-  void _setKeyState(LogicalKeyboardKey key, bool state) {
-    final inputKey = InputKey.values.firstWhereOrNull((el) => el.logicalKey == key);
+  bool _setKeyState(LogicalKeyboardKey key, bool state) {
+    final inputKey =
+        InputKey.values.firstWhereOrNull((el) => el.logicalKey == key);
     if (inputKey != null) {
       _keyboard[inputKey] = state;
+      return true;
     }
-  }
-
-  void stop() {
-    RawKeyboard.instance.removeListener(_onKey);
+    return false;
   }
 }

--- a/lib/features/vm/machine.dart
+++ b/lib/features/vm/machine.dart
@@ -73,7 +73,6 @@ class VirtualMachine {
     ticker = Ticker((_) => tick());
     ticker.start();
     _ticker = ticker;
-    input.start();
     sound.start();
   }
 
@@ -88,7 +87,6 @@ class VirtualMachine {
 
   void stop() {
     sound.stop();
-    input.stop();
     if (_ticker != null) {
       _ticker!.stop();
       _ticker = null;


### PR DESCRIPTION
Keystrokes tracked by the input manager are being detected directly by RawKeyboard, which cant mark key events as handled. As consequence, there is a very annoying sound every time the player keeps space pressed on macOS.